### PR TITLE
Add flow sensors

### DIFF
--- a/custom_components/checkwatt/sensor.py
+++ b/custom_components/checkwatt/sensor.py
@@ -12,7 +12,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE, UnitOfEnergy
+from homeassistant.const import PERCENTAGE, UnitOfEnergy, UnitOfPower
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -148,6 +148,33 @@ CHECKWATT_ENERGY_SENSORS: dict[str, SensorEntityDescription] = {
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
         translation_key="export_sensor",
+    ),
+    "solar_power": SensorEntityDescription(
+        key="solar_power",
+        name="Current Solar Production",
+        icon="mdi:solar-power-variant-outline",
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        translation_key="solar_power_sensor",
+    ),
+    "battery_power": SensorEntityDescription(
+        key="battery_power",
+        name="Current Battery Power",
+        icon="mdi:home-battery",
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        translation_key="battery_power_sensor",
+    ),
+    "grid_power": SensorEntityDescription(
+        key="grid_power",
+        name="Current Grid Power",
+        icon="mdi:transmission-tower-export",
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        translation_key="grid_power_sensor",
     ),
 }
 

--- a/custom_components/checkwatt/translations/en.json
+++ b/custom_components/checkwatt/translations/en.json
@@ -97,6 +97,15 @@
             "export_sensor": {
                 "name": "Export Energy"
             },
+            "solar_power_sensor": {
+                "name": "Current Solar Production"
+            },
+            "battery_power_sensor": {
+                "name": "Current Battery Power"
+            },
+            "grid_power_sensor": {
+                "name": "Current Grid Power"
+            },
             "spot_price_sensor": {
                 "name": "Spot Price",
                 "state_attributes": {

--- a/custom_components/checkwatt/translations/sv.json
+++ b/custom_components/checkwatt/translations/sv.json
@@ -97,6 +97,15 @@
             "export_sensor": {
                 "name": "Exporterad Energi"
             },
+            "solar_power_sensor": {
+                "name": "Aktuell solenergi produktion"
+            },
+            "battery_power_sensor": {
+                "name": "Aktuell batteri effekt"
+            },
+            "grid_power_sensor": {
+                "name": "Aktuell nät effekt"
+            },
             "spot_price_sensor": {
                 "name": "Spotpris",
                 "state_attributes": {


### PR DESCRIPTION
This allows to show the current flow of energy in HA, for example with power-flow-card-plus. We're already fetching the data, but not providing any sensors for these values.